### PR TITLE
Add PDF compilation utility with bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # split-real-books
 
-Simple script to split pdf files (in my use-case real books) into multiple files thanks to a configuration file.
+Simple script to split pdf files (in my use-case real books) into multiple
+files thanks to a configuration file. It can now also compile the generated
+PDFs into a single song book with a convenient table of contents.
 
 # Configuration
 
@@ -8,6 +10,40 @@ Check `config.example.yaml` for the configuration format.
 
 # Usage
 
+## Split PDFs based on the configuration
+
 ```
 python split-real-books.py
 ```
+
+## Compile the generated PDFs into a single book
+
+Once the songs have been extracted you can merge the PDFs that live in an
+output folder (for example `output_songs`) into a single lightweight PDF with
+an automatically generated table of contents:
+
+```
+python split-real-books.py --compile-directory output_songs --compress
+```
+
+The command above creates `CombinedRealBook.pdf` in `output_songs/`. Every song
+is listed alphabetically in the PDF outline so you can quickly jump to any
+sheet. The optional `--compress` flag applies additional stream compression to
+keep the resulting file small enough for mobile use.
+
+If you run the splitter against a configuration that contains several
+`output_directory` entries, you can automatically compile each of them right
+after the split with:
+
+```
+python split-real-books.py --compile-from-config
+```
+
+Additional options:
+
+- `--compiled-filename`: customise the name of the merged PDF (defaults to
+  `CombinedRealBook.pdf`).
+- `--compile-directory`: can be passed multiple times to merge several folders
+  in one run.
+- `--compress`: reduce the size of the generated compilation by compressing the
+  internal PDF streams.

--- a/split-real-books.py
+++ b/split-real-books.py
@@ -231,7 +231,7 @@ def compile_directory(directory, output_file, compress=False):
                     page.compress_content_streams()
                 writer.add_page(page)
 
-            writer.add_outline_item(song_name, writer.pages[first_page_index])
+            writer.add_outline_item(song_name, first_page_index)
 
     with open(output_file, "wb") as out_file:
         writer.write(out_file)

--- a/split-real-books.py
+++ b/split-real-books.py
@@ -231,7 +231,11 @@ def compile_directory(directory, output_file, compress=False):
                     page.compress_content_streams()
                 writer.add_page(page)
 
-            writer.add_outline_item(song_name, first_page_index)
+            # Use the page reference from the writer to satisfy pypdf 6.x,
+            # which requires outline destinations to be linked to pages owned
+            # by the target writer instead of relying on numeric indices.
+            destination_page = writer.pages[first_page_index]
+            writer.add_outline_item(song_name, destination_page)
 
     with open(output_file, "wb") as out_file:
         writer.write(out_file)

--- a/split-real-books.py
+++ b/split-real-books.py
@@ -4,7 +4,9 @@ import logging
 import os
 import time
 
-from pypdf import PdfReader, PdfWriter
+from io import BytesIO
+
+from pypdf import PdfMerger, PdfReader, PdfWriter
 from yaml import Loader, load
 
 logger = logging.getLogger()
@@ -69,7 +71,18 @@ def extract_songs_from_pdf(input_pdf, config, offset, output_dir, abbreviation="
 
 def main():
     args = parse_args()
+
+    if args.compile_directory:
+        compile_directories(
+            args.compile_directory,
+            args.compiled_filename,
+            compress=args.compress,
+        )
+        return
+
     config = read_config(args.config_file)
+
+    output_directories = set()
 
     for real_book_config in config:
         output_directory = (
@@ -77,6 +90,7 @@ def main():
             if "output_directory" in real_book_config
             else "output_songs"
         )
+        output_directories.add(output_directory)
         abbreviation = (
             real_book_config["abbreviation"]
             if "abbreviation" in real_book_config
@@ -88,6 +102,13 @@ def main():
             real_book_config["offset"],
             output_directory,
             abbreviation,
+        )
+
+    if args.compile_from_config:
+        compile_directories(
+            sorted(output_directories),
+            args.compiled_filename,
+            compress=args.compress,
         )
 
     logger.info("Runtime : %.2f seconds." % (time.time() - start_time))
@@ -113,10 +134,122 @@ def parse_args():
         type=str,
         default="config.yaml",
     )
+    parser.add_argument(
+        "--compile-directory",
+        help="Compile the PDFs contained in the provided directory into a single file."
+        " Can be specified multiple times to compile several folders at once.",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
+        "--compiled-filename",
+        help="Filename of the generated compilation PDF (default: CombinedRealBook.pdf).",
+        default="CombinedRealBook.pdf",
+    )
+    parser.add_argument(
+        "--compile-from-config",
+        help="After splitting, compile each output directory defined in the config.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--compress",
+        help="Compress PDF content streams when compiling to reduce the final file size.",
+        action="store_true",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel, format=format)
     return args
+
+
+def compile_directories(directories, compiled_filename, compress=False):
+    """Compile a list of directories into combined PDF files.
+
+    Args:
+        directories (list[str]): List of directories containing PDFs to merge.
+        compiled_filename (str): Name of the combined PDF that will be created in
+            each directory.
+        compress (bool, optional): Compress PDF content streams before merging.
+    """
+
+    for directory in directories:
+        directory = os.path.abspath(directory)
+        if not os.path.isdir(directory):
+            logger.warning(f"Skipping '{directory}' because it is not a directory.")
+            continue
+        output_file = os.path.join(directory, compiled_filename)
+        try:
+            compile_directory(directory, output_file, compress=compress)
+        except Exception as exc:
+            logger.error(f"Failed to compile '{directory}': {exc}")
+
+
+def compile_directory(directory, output_file, compress=False):
+    """Compile all PDF files in a directory into a single PDF.
+
+    The generated PDF features a table of contents that lists every song in
+    alphabetical order. The outline entries directly link to the first page of
+    each song.
+
+    Args:
+        directory (str): Directory that contains the PDFs to be merged.
+        output_file (str): Path of the resulting combined PDF.
+        compress (bool, optional): Compress PDF content streams before merging to
+            reduce the file size. Defaults to False.
+    """
+
+    output_file = os.path.abspath(output_file)
+
+    pdf_files = [
+        os.path.abspath(os.path.join(root, filename))
+        for root, _, filenames in os.walk(directory)
+        for filename in filenames
+        if filename.lower().endswith(".pdf")
+        and os.path.abspath(os.path.join(root, filename)) != output_file
+    ]
+
+    if not pdf_files:
+        logger.warning(f"No PDF files were found in '{directory}'.")
+        return
+
+    pdf_files.sort(key=lambda path: os.path.splitext(os.path.basename(path))[0].casefold())
+
+    merger = PdfMerger()
+    in_memory_buffers = []
+
+    try:
+        current_page = 0
+
+        for pdf_path in pdf_files:
+            song_name = os.path.splitext(os.path.basename(pdf_path))[0]
+            with open(pdf_path, "rb") as file_obj:
+                reader = PdfReader(file_obj)
+                page_count = len(reader.pages)
+
+                if compress:
+                    for page in reader.pages:
+                        page.compress_content_streams()
+                    writer = PdfWriter()
+                    writer.append_pages_from_reader(reader)
+                    buffer = BytesIO()
+                    writer.write(buffer)
+                    buffer.seek(0)
+                    merger.append(buffer, import_outline=False)
+                    in_memory_buffers.append(buffer)
+                else:
+                    merger.append(reader, import_outline=False)
+
+            merger.add_outline_item(song_name, current_page)
+            current_page += page_count
+
+        with open(output_file, "wb") as out_file:
+            merger.write(out_file)
+
+        logger.info(f"Created compilation: {output_file}")
+    finally:
+        merger.close()
+        for buffer in in_memory_buffers:
+            buffer.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add CLI options to compile extracted songs into a single PDF with alphabetical bookmarks
- allow optional compression of PDF streams to keep the merged file lightweight
- document the new compilation workflow in the README

## Testing
- python -m compileall split-real-books.py

------
https://chatgpt.com/codex/tasks/task_e_68ddaeae4510832c9f800d08cf3d9bae